### PR TITLE
Ping in regression node

### DIFF
--- a/nim-test-node/regression/main.nim
+++ b/nim-test-node/regression/main.nim
@@ -1,6 +1,5 @@
 import stew/endians2, stew/byteutils, tables, strutils, os, json
 import chronos, chronos/apps/http/httpserver
-import env
 import std/[strformat, random, hashes]
 import libp2p, libp2p/[muxers/mplex/lpchannel, stream/connection, crypto/secp, multiaddress]
 import libp2p/protocols/[pubsub/pubsubpeer, pubsub/rpc/messages, ping]
@@ -9,6 +8,8 @@ import sequtils, math, metrics, metrics/chronos_httpserver
 from times import getTime, Time, toUnix, fromUnix, `-`, initTime, `$`, inMilliseconds, toUnixFloat
 from nativesockets import getHostname
 
+import env
+import ping_utils
 
 template toUnixNanoseconds(t: times.Time): int64 =
   (t.toUnixFloat() * 1_000_000_000).int64
@@ -254,6 +255,8 @@ proc main {.async.} =
   configureGossipsubParams(gossipSub)
   subscribGossipsubTopic(gossipSub, "test")
   switch.mount(gossipSub)
+  let pingProtocol = Ping.new(rng = rng)
+  switch.mount(pingProtocol)
   await switch.start()
 
   # Metrics
@@ -278,6 +281,9 @@ proc main {.async.} =
   await sleepAsync(5.seconds)
   info "Mesh details ", meshSize = gossipSub.mesh.getOrDefault("test").len,
     peersConnected = gossipSub.gossipsub.getOrDefault("test").len
+
+  # Periodic mesh-only pings
+  asyncSpawn pingMeshLoop(switch, pingProtocol, gossipSub, "test")
 
   info "Starting listening endpoint for publish controller"
   discard gossipSub.startHttpServer(myId)

--- a/nim-test-node/regression/ping_utils.nim
+++ b/nim-test-node/regression/ping_utils.nim
@@ -8,6 +8,10 @@ import libp2p/protocols/pubsub/gossipsub
 const
   MeshPingInterval = 45.seconds
   MeshPingTimeout  = 4.seconds
+  MeshDialTimeout  = 4.seconds
+  MeshCloseTimeout = 2.seconds
+  SlowDialLog      = 500.milliseconds
+  SlowCloseLog     = 500.milliseconds
 
 proc meshPeerIds*(gossipSub: GossipSub, topic: string): seq[PeerId] =
   ## Only peers in the mesh for `topic` (convert HashSet[PubSubPeer] -> seq[PeerId])
@@ -27,19 +31,42 @@ proc pingMeshPeer*(switch: Switch, pingProtocol: Ping, peerId: PeerId) {.async.}
     return
 
   var stream: Stream
+  let dialStart = Moment.now()
   try:
-    stream = await switch.dial(peerId, addrs, PingCodec)
+    stream = await switch.dial(peerId, addrs, PingCodec).wait(MeshDialTimeout)
+
+    let dialDur = Moment.now() - dialStart
+    if dialDur >= SlowDialLog:
+      warn "mesh ping: slow dial", peerId = peerId, dialMs = dialDur.milliseconds
+
+    let pingStart = Moment.now()
     let latency = await pingProtocol.ping(stream).wait(MeshPingTimeout)
-    info "mesh ping", peerId = peerId, latency = latency
+    let pingDur = Moment.now() - pingStart
+
+    info "mesh ping",
+      peerId = peerId,
+      latency = latency,
+      dialMs = dialDur.milliseconds,
+      pingMs = pingDur.milliseconds
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:
-    warn "mesh ping failed", peerId = peerId, error = exc.msg
+    let dialDur = Moment.now() - dialStart
+    warn "mesh ping failed", peerId = peerId, error = exc.msg, dialMs = dialDur.milliseconds
   finally:
     if not stream.isNil and not stream.closed:
-      try: await stream.close()
-      except CancelledError as exc: raise exc
-      except CatchableError: discard
+      let closeStart = Moment.now()
+      try:
+        # Make close observable: if it never completes, you'll never see "slow close" today.
+        await stream.close().wait(MeshCloseTimeout)
+      except CancelledError as exc:
+        raise exc
+      except CatchableError as exc:
+        warn "mesh ping: stream close failed", peerId = peerId, error = exc.msg
+      finally:
+        let closeDur = Moment.now() - closeStart
+        if closeDur >= SlowCloseLog:
+          warn "mesh ping: slow close", peerId = peerId, closeMs = closeDur.milliseconds
 
 proc pingMeshOnce*(switch: Switch, pingProtocol: Ping, gossipSub: GossipSub, topic: string) {.async.} =
   let peers = gossipSub.meshPeerIds(topic)

--- a/nim-test-node/regression/ping_utils.nim
+++ b/nim-test-node/regression/ping_utils.nim
@@ -1,0 +1,60 @@
+import chronos
+import std/[tables, sets]
+
+import libp2p
+import libp2p/protocols/ping
+import libp2p/protocols/pubsub/gossipsub
+
+const
+  MeshPingInterval = 45.seconds
+  MeshPingTimeout  = 4.seconds
+
+proc meshPeerIds*(gossipSub: GossipSub, topic: string): seq[PeerId] =
+  ## Only peers in the mesh for `topic` (convert HashSet[PubSubPeer] -> seq[PeerId])
+  let peers: HashSet[PubSubPeer] = gossipSub.mesh.getOrDefault(topic, initHashSet[PubSubPeer]())
+  result = newSeqOfCap[PeerId](peers.len)
+  for p in peers:
+    result.add(p.peerId)
+
+proc pingMeshPeer*(switch: Switch, pingProtocol: Ping, peerId: PeerId) {.async.} =
+  let book = switch.peerStore[AddressBook]
+
+  if not book.book.hasKey(peerId):
+    return
+
+  let addrs = book[peerId]
+  if addrs.len == 0:
+    return
+
+  var stream: Stream
+  try:
+    stream = await switch.dial(peerId, addrs, PingCodec)
+    let latency = await pingProtocol.ping(stream).wait(MeshPingTimeout)
+    info "mesh ping", peerId = peerId, latency = latency
+  except CancelledError as exc:
+    raise exc
+  except CatchableError as exc:
+    warn "mesh ping failed", peerId = peerId, error = exc.msg
+  finally:
+    if not stream.isNil and not stream.closed:
+      try: await stream.close()
+      except CancelledError as exc: raise exc
+      except CatchableError: discard
+
+proc pingMeshOnce*(switch: Switch, pingProtocol: Ping, gossipSub: GossipSub, topic: string) {.async.} =
+  let peers = gossipSub.meshPeerIds(topic)
+  if peers.len == 0:
+    return
+
+  var futs: seq[Future[void]] = @[]
+  for pid in peers:
+    if pid == switch.peerInfo.peerId: continue
+    futs.add(switch.pingMeshPeer(pingProtocol, pid))
+
+  if futs.len > 0:
+    await allFutures(futs)
+
+proc pingMeshLoop*(switch: Switch, pingProtocol: Ping, gossipSub: GossipSub, topic: string) {.async.} =
+  while true:
+    await switch.pingMeshOnce(pingProtocol, gossipSub, topic)
+    await sleepAsync(MeshPingInterval)

--- a/nim-test-node/regression/ping_utils.nim
+++ b/nim-test-node/regression/ping_utils.nim
@@ -58,7 +58,7 @@ proc pingMeshPeer*(switch: Switch, pingProtocol: Ping, peerId: PeerId) {.async.}
       let closeStart = Moment.now()
       try:
         # Make close observable: if it never completes, you'll never see "slow close" today.
-        await stream.close().wait(MeshCloseTimeout)
+        await stream.closeWithEOF().wait(MeshCloseTimeout)
       except CancelledError as exc:
         raise exc
       except CatchableError as exc:


### PR DESCRIPTION
Quic has a default timeout of 1 minute.
During the experiment setup, the connection phase and readiness check of all pods can take more than 1 minute. This makes that the nodes can start disconnecting if using Quic, never reaching a mesh ready, making impossible to start publishing messages.
This ping is done each 45seconds to avoid that. Ping is only made to nodes with full-message connection.