### PR TITLE
Service Discovery connectivity issues fix

### DIFF
--- a/nim-test-node/service-discovery/env.nim
+++ b/nim-test-node/service-discovery/env.nim
@@ -25,6 +25,7 @@ type
     advertExpiry*: Duration
     xprPublishing*: bool
     maxConnections*: int
+    maxBootstraps*: int
 
 proc `$`(c: NodeConfig): string =
   "NodeConfig(" &
@@ -44,6 +45,7 @@ proc `$`(c: NodeConfig): string =
     ", advertExpiry=" & $c.advertExpiry &
     ", xprPublishing=" & $c.xprPublishing &
     ", maxConnections=" & $c.maxConnections &
+    ", maxBootstraps=" & $c.maxBootstraps &
   ")"
 
 
@@ -151,6 +153,9 @@ proc getNodeConfig*(): Result[NodeConfig, string] =
   let maxConnections = parseIntEnv("MAXCONNECTIONS", "200").valueOr:
     return err(error)
 
+  let maxBootstraps = parseIntEnv("MAXBOOTSTRAPS", "1").valueOr:
+    return err(error)
+
   let listenAddress =
     if muxer == "quic":
       "/ip4/0.0.0.0/udp/" & $listenPort & "/quic-v1"
@@ -174,7 +179,8 @@ proc getNodeConfig*(): Result[NodeConfig, string] =
     ipSimCoefficient: ipSimCoefficient,
     advertExpiry: advertExpirySeconds.seconds,
     xprPublishing: xprPublishing,
-    maxConnections: maxConnections
+    maxConnections: maxConnections,
+    maxBootstraps: maxBootstraps
   )
 
   info "Node config loaded", cfg = $cfg

--- a/nim-test-node/service-discovery/env.nim
+++ b/nim-test-node/service-discovery/env.nim
@@ -24,6 +24,28 @@ type
     ipSimCoefficient*: float64
     advertExpiry*: Duration
     xprPublishing*: bool
+    maxConnections*: int
+
+proc `$`(c: NodeConfig): string =
+  "NodeConfig(" &
+    "role=" & $c.role &
+    ", nodeIndex=" & $c.nodeIndex &
+    ", muxer=" & c.muxer &
+    ", listenAddress=" & c.listenAddress &
+    ", bootstrapService=" & c.bootstrapService &
+    ", advertiseServices=" & $c.advertiseServices &
+    ", discoverServices=" & $c.discoverServices &
+    ", listenPort=" & $c.listenPort &
+    ", healthPort=" & $c.healthPort &
+    ", lookupInterval=" & $c.lookupInterval &
+    ", startupJitterMs=" & $c.startupJitterMs &
+    ", safetyParam=" & $c.safetyParam &
+    ", ipSimCoefficient=" & $c.ipSimCoefficient &
+    ", advertExpiry=" & $c.advertExpiry &
+    ", xprPublishing=" & $c.xprPublishing &
+    ", maxConnections=" & $c.maxConnections &
+  ")"
+
 
 proc parseIntEnv(name: string, defaultValue: string): Result[int, string] =
   let raw = getEnv(name, defaultValue)
@@ -155,13 +177,6 @@ proc getNodeConfig*(): Result[NodeConfig, string] =
     maxConnections: maxConnections
   )
 
-  info "Node config loaded",
-    role = cfg.role,
-    nodeIndex = cfg.nodeIndex,
-    muxer = cfg.muxer,
-    listenAddress = cfg.listenAddress,
-    advertiseServices = cfg.advertiseServices,
-    discoverServices = cfg.discoverServices,
-    bootstrapService = cfg.bootstrapService
+  info "Node config loaded", cfg = $cfg
 
   ok(cfg)

--- a/nim-test-node/service-discovery/env.nim
+++ b/nim-test-node/service-discovery/env.nim
@@ -126,6 +126,9 @@ proc getNodeConfig*(): Result[NodeConfig, string] =
   if role in [RoleDiscoverer, RoleHybrid] and discoverServices.len == 0:
     return err("DISCOVER_SERVICES is required for " & $role)
 
+  let maxConnections = parseIntEnv("MAXCONNECTIONS", "200").valueOr:
+    return err(error)
+
   let listenAddress =
     if muxer == "quic":
       "/ip4/0.0.0.0/udp/" & $listenPort & "/quic-v1"
@@ -149,6 +152,7 @@ proc getNodeConfig*(): Result[NodeConfig, string] =
     ipSimCoefficient: ipSimCoefficient,
     advertExpiry: advertExpirySeconds.seconds,
     xprPublishing: xprPublishing,
+    maxConnections: maxConnections
   )
 
   info "Node config loaded",

--- a/nim-test-node/service-discovery/env.nim
+++ b/nim-test-node/service-discovery/env.nim
@@ -109,7 +109,7 @@ proc getNodeConfig*(): Result[NodeConfig, string] =
       parseIntEnv("STARTUP_JITTER_MS", "0").valueOr:
         return err(error)
     else:
-      let step = parseIntEnv("STARTUP_JITTER_STEP_MS", "200").valueOr:
+      let step = parseIntEnv("STARTUP_JITTER_STEP_MS", "10").valueOr:
         return err(error)
       nodeIndex * step
 

--- a/nim-test-node/service-discovery/helpers.nim
+++ b/nim-test-node/service-discovery/helpers.nim
@@ -4,13 +4,13 @@ import chronicles
 import libp2p, libp2p/[multiaddress]
 import libp2p/protocols/[kademlia, service_discovery]
 
-proc buildSwitch*(muxer: string, listenAddress: string): Switch =
+proc buildSwitch*(muxer: string, max_connections: int, listenAddress: string): Switch =
   var builder = SwitchBuilder
     .new()
     .withNoise()
     .withRng(libp2p.newRng())
     .withAddresses(@[MultiAddress.init(listenAddress).tryGet()])
-    .withMaxConnections(200)
+    .withMaxConnections(max_connections)
 
   case muxer
   of "quic":

--- a/nim-test-node/service-discovery/helpers.nim
+++ b/nim-test-node/service-discovery/helpers.nim
@@ -63,8 +63,15 @@ proc resolveService*(
   ok(addrs)
 
 proc connectToBootstraps*(
-    switch: Switch, muxer: string, service: string, defaultPort: Port
+    switch: Switch,
+    muxer: string,
+    service: string,
+    defaultPort: Port,
+    maxConnections: int
 ): Future[Result[seq[(PeerId, seq[MultiAddress])], string]] {.async.} =
+  if maxConnections <= 0:
+    return err("maxConnections must be greater than 0")
+
   let addrsRes = await resolveService(muxer, service, defaultPort)
   let addrs = addrsRes.valueOr:
     return err("Failed to resolve bootstrap service '" & service & "': " & error)
@@ -73,6 +80,9 @@ proc connectToBootstraps*(
   var lastErr = ""
 
   for addr in addrs:
+    if bootstraps.len >= maxConnections:
+      break
+
     var backoff = 1.seconds
     for attempt in 1 .. 10:
       try:

--- a/nim-test-node/service-discovery/helpers.nim
+++ b/nim-test-node/service-discovery/helpers.nim
@@ -124,8 +124,11 @@ proc mountServiceDiscovery*(
     xprPublishing = xprPublishing,
   )
 
+  info "Starting service discovery"
   await disco.start()
+  info "Mouting service discovery"
   switch.mount(disco)
+  info "Service discovery mounted"
   disco
 
 proc startHealthServer*(port: Port): Future[HttpServerRef] {.async.} =

--- a/nim-test-node/service-discovery/helpers.nim
+++ b/nim-test-node/service-discovery/helpers.nim
@@ -76,7 +76,8 @@ proc connectToBootstraps*(
     var backoff = 1.seconds
     for attempt in 1 .. 10:
       try:
-        let peerId = await switch.connect(addr, allowUnknownPeerId = true).wait(10.seconds)
+        let peerId =
+          await switch.connect(addr, allowUnknownPeerId = true).wait(10.seconds)
         notice "Connected to bootstrap", address = addr, peerId, attempt
         bootstraps.add((peerId, @[addr]))
         break
@@ -89,24 +90,21 @@ proc connectToBootstraps*(
 
   if bootstraps.len == 0:
     return err(
-      "Could not connect to any bootstrap resolved from '" & service &
-      "' (candidates=" & $addrs.len & "). Last error: " & lastErr
+      "Could not connect to any bootstrap resolved from '" & service & "' (candidates=" &
+        $addrs.len & "). Last error: " & lastErr
     )
 
   ok(bootstraps)
 
 proc mountServiceDiscovery*(
     switch: Switch,
-    bootstrapNodes: seq[(PeerId, seq[MultiAddress])],
     safetyParam: float64,
     ipSimCoefficient: float64,
     advertExpiry: Duration,
     xprPublishing: bool,
-): Future[ServiceDiscovery] {.async.} =
-  let kadCfg = KadDHTConfig.new(
-    validator = ExtEntryValidator(),
-    selector = ExtEntrySelector(),
-  )
+): ServiceDiscovery =
+  let kadCfg =
+    KadDHTConfig.new(validator = ExtEntryValidator(), selector = ExtEntrySelector())
 
   let discoCfg = ServiceDiscoveryConfig.new(
     safetyParam = safetyParam,
@@ -116,7 +114,7 @@ proc mountServiceDiscovery*(
 
   let disco = ServiceDiscovery.new(
     switch,
-    bootstrapNodes = bootstrapNodes,
+    bootstrapNodes = @[],
     config = kadCfg,
     rng = libp2p.newRng(),
     codec = ExtendedServiceDiscoveryCodec,
@@ -124,11 +122,7 @@ proc mountServiceDiscovery*(
     xprPublishing = xprPublishing,
   )
 
-  info "Starting service discovery"
-  await disco.start()
-  info "Mouting service discovery"
   switch.mount(disco)
-  info "Service discovery mounted"
   disco
 
 proc startHealthServer*(port: Port): Future[HttpServerRef] {.async.} =
@@ -140,9 +134,7 @@ proc startHealthServer*(port: Port): Future[HttpServerRef] {.async.} =
 
     if req.meth == MethodGet and (req.uri.path == "/health" or req.uri.path == "/ready"):
       return await req.respond(
-        Http200,
-        "ok",
-        HttpTable.init([("Content-Type", "text/plain")]),
+        Http200, "ok", HttpTable.init([("Content-Type", "text/plain")])
       )
 
     return await req.respond(Http404, "Not Found")
@@ -150,7 +142,9 @@ proc startHealthServer*(port: Port): Future[HttpServerRef] {.async.} =
   let addrs = initTAddress("0.0.0.0:" & $port)
   let serverRes = HttpServerRef.new(addrs, handler)
   if serverRes.isErr():
-    raise newException(CatchableError, "Failed to create health HTTP server: " & $serverRes.error)
+    raise newException(
+      CatchableError, "Failed to create health HTTP server: " & $serverRes.error
+    )
 
   let server = serverRes.get()
   server.start()

--- a/nim-test-node/service-discovery/main.nim
+++ b/nim-test-node/service-discovery/main.nim
@@ -2,6 +2,7 @@ import chronos, chronicles
 import std/sequtils
 import libp2p, libp2p/[multiaddress]
 import libp2p/extended_peer_record
+import libp2p/protocols/kademlia
 import env, helpers, core
 
 proc main() {.async.} =
@@ -10,44 +11,36 @@ proc main() {.async.} =
     quit(1)
 
   var switch = buildSwitch(cfg.muxer, cfg.maxConnections, cfg.listenAddress)
+
+  let disco = mountServiceDiscovery(
+    switch, cfg.safetyParam, cfg.ipSimCoefficient, cfg.advertExpiry, cfg.xprPublishing
+  )
+
   await switch.start()
 
   let selfId = switch.peerInfo.peerId
   notice "Service discovery node started",
-    peerId = $selfId,
-    role = cfg.role,
-    listen = cfg.listenAddress
+    peerId = $selfId, role = cfg.role, listen = cfg.listenAddress
 
-  var bootstrapNodes: seq[(PeerId, seq[MultiAddress])] = @[]
   if cfg.role != RoleBootstrap:
     if cfg.startupJitterMs > 0:
       notice "Applying startup jitter", delayMs = cfg.startupJitterMs
       await sleepAsync(cfg.startupJitterMs.milliseconds)
 
-    let connectedBootstraps = await connectToBootstraps(
-      switch,
-      cfg.muxer,
-      cfg.bootstrapService,
-      cfg.listenPort,
-    )
-    bootstrapNodes = connectedBootstraps.valueOr:
-      error "Failed to connect to bootstrap nodes", service = cfg.bootstrapService, error
+    let connectedBootstraps =
+      await connectToBootstraps(switch, cfg.muxer, cfg.bootstrapService, cfg.listenPort)
+    let bootstrapNodes = connectedBootstraps.valueOr:
+      error "Failed to connect to bootstrap nodes",
+        service = cfg.bootstrapService, error
       quit(1)
 
-  let disco = await mountServiceDiscovery(
-    switch,
-    bootstrapNodes,
-    cfg.safetyParam,
-    cfg.ipSimCoefficient,
-    cfg.advertExpiry,
-    cfg.xprPublishing,
-  )
+    disco.updatePeers(bootstrapNodes)
+    await disco.bootstrap(forceRefresh = true)
 
   discard await startHealthServer(cfg.healthPort)
 
-  let advertisedServices = cfg.advertiseServices.mapIt(
-    ServiceInfo(id: it, data: cfg.serviceData)
-  )
+  let advertisedServices =
+    cfg.advertiseServices.mapIt(ServiceInfo(id: it, data: cfg.serviceData))
 
   case cfg.role
   of RoleBootstrap:

--- a/nim-test-node/service-discovery/main.nim
+++ b/nim-test-node/service-discovery/main.nim
@@ -28,7 +28,7 @@ proc main() {.async.} =
       await sleepAsync(cfg.startupJitterMs.milliseconds)
 
     let connectedBootstraps =
-      await connectToBootstraps(switch, cfg.muxer, cfg.bootstrapService, cfg.listenPort, cfg.bootstrapConnections)
+      await connectToBootstraps(switch, cfg.muxer, cfg.bootstrapService, cfg.listenPort, cfg.maxBootstraps)
     let bootstrapNodes = connectedBootstraps.valueOr:
       error "Failed to connect to bootstrap nodes",
         service = cfg.bootstrapService, error

--- a/nim-test-node/service-discovery/main.nim
+++ b/nim-test-node/service-discovery/main.nim
@@ -9,7 +9,7 @@ proc main() {.async.} =
     error "Invalid node configuration", error
     quit(1)
 
-  var switch = buildSwitch(cfg.muxer, cfg.listenAddress)
+  var switch = buildSwitch(cfg.muxer, cfg.maxConnections, cfg.listenAddress)
   await switch.start()
 
   let selfId = switch.peerInfo.peerId

--- a/nim-test-node/service-discovery/main.nim
+++ b/nim-test-node/service-discovery/main.nim
@@ -28,7 +28,7 @@ proc main() {.async.} =
       await sleepAsync(cfg.startupJitterMs.milliseconds)
 
     let connectedBootstraps =
-      await connectToBootstraps(switch, cfg.muxer, cfg.bootstrapService, cfg.listenPort)
+      await connectToBootstraps(switch, cfg.muxer, cfg.bootstrapService, cfg.listenPort, cfg.bootstrapConnections)
     let bootstrapNodes = connectedBootstraps.valueOr:
       error "Failed to connect to bootstrap nodes",
         service = cfg.bootstrapService, error

--- a/nim-test-node/service-discovery/test_node.nimble
+++ b/nim-test-node/service-discovery/test_node.nimble
@@ -7,6 +7,6 @@ description   = "A test node for libp2p service discovery"
 license       = "MIT"
 skipDirs      = @[]
 
-requires "nim >= 2.2.0",
+requires "nim >= 2.2.4",
           "nimcrypto 0.6.4",
           "https://github.com/vacp2p/nim-libp2p#26e181e4dd65188051ab4783bcc538ed9579644f" # 2.0.0

--- a/nim-test-node/service-discovery/test_node.nimble
+++ b/nim-test-node/service-discovery/test_node.nimble
@@ -9,4 +9,4 @@ skipDirs      = @[]
 
 requires "nim >= 2.2.0",
           "nimcrypto 0.6.4",
-          "libp2p#d4cd68b91b82f34a0ede3766ab1ca8119d5015f8"
+          "https://github.com/vacp2p/nim-libp2p#26e181e4dd65188051ab4783bcc538ed9579644f" # 2.0.0


### PR DESCRIPTION
Before we:
1. Start switch
2. Connect nodes to bootstraps
3. Start service discovery with those bootstrap nodes

Now we:
1. Start switch and service discovery
2. Connect to bootstrap nodes
3. Update service discovery with those bootstrap nodes

This makes startup phase much cleaner and less error prone. Thanks a lot to @gmelodie 