### PR TITLE
Speed up regression node build: drop unused ggplotnim, merge apt layers

### DIFF
--- a/nim-test-node/regression/Dockerfile_amd64
+++ b/nim-test-node/regression/Dockerfile_amd64
@@ -3,33 +3,14 @@ FROM debian:bookworm-slim AS builder
 
 WORKDIR /node
 
+# All build + runtime packages in one layer (previously four separate apt-get
+# update/install passes that re-installed curl/git/build-essential/ca-certs/etc.).
 RUN apt-get update && apt-get install -y \
     curl git build-essential ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update && apt-get install -y \
-    gcc-multilib g++-multilib libc6-dev-i386 \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update && apt-get install -y \
-    curl git build-essential ca-certificates \
-    gcc libc6-dev-i386 \
+    gcc gcc-multilib g++-multilib libc6-dev-i386 \
     libssl3 iproute2 procps \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
-
-
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    ca-certificates \
-    libssl3 \
-    iproute2 \
-    curl \
-    procps \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
-
 
 RUN git config --global http.sslVerify false
 

--- a/nim-test-node/regression/test_node.nimble
+++ b/nim-test-node/regression/test_node.nimble
@@ -11,5 +11,4 @@ skipDirs      = @[]
 
 requires "nim >= 2.2.0",
           "nimcrypto 0.6.4",
-          "https://github.com/vacp2p/nim-libp2p#26e181e4dd65188051ab4783bcc538ed9579644f", # 2.0.0
-          "ggplotnim"
+          "https://github.com/vacp2p/nim-libp2p#26e181e4dd65188051ab4783bcc538ed9579644f" # 2.0.0


### PR DESCRIPTION
## What
Two build-only changes to the regression test node so the image builds faster:

1. **Drop `ggplotnim`** — it's in `requires` but the node never imports it. It drags in a big transitive tree (arraymancer, cairo, pixie, opencl, nimcuda, datamancer, …) that gets fetched on every build for nothing.
2. **Merge the four `apt-get` layers into one** — they ran `apt-get update` four times and re-installed curl/git/build-essential/ca-certificates/libssl3/etc. two or three times. The single layer installs the union of what the four installed.