### PR TITLE
Stagger bootstrap dial by pod index instead of a flat start sleep

### DIFF
--- a/nim-test-node/regression/env.nim
+++ b/nim-test-node/regression/env.nim
@@ -16,7 +16,10 @@ let
   # simultaneous-dial collisions. Mainly for Shadow, which starts all hosts at the same
   # simulated instant; real deployments get this spread naturally. Node availability
   # before connect is handled by the readiness probe + publish_not_ready_addresses
-  # (10ksim#315), so no flat sync delay is needed here.
+  # (10ksim#315), so no flat sync delay is needed here. The flat delay also guarded against
+  # static-mode connection hoarding (early nodes filling their slots before latecomers dial);
+  # that stays fine at 1000 nodes here, since each dials a sparse fixed set so inbound sits at
+  # ~CONNECTTO on average, well under the connection cap.
   startupJitterStepMs* = parseInt(getEnv("STARTUP_JITTER_STEP_MS", "50"))
   metricsIntervalS* = parseInt(getEnv("METRICS_INTERVAL_S", "300"))  #storeMetrics scrape interval (s); short for shadow
 

--- a/nim-test-node/regression/env.nim
+++ b/nim-test-node/regression/env.nim
@@ -12,7 +12,12 @@ let
   prometheusPort* = Port(8008)
   myPort* = Port(5000)
   chunks* = parseInt(getEnv("FRAGMENTS", "1"))                  #No. of fragments for each message
-  startupJitterStepMs* = parseInt(getEnv("STARTUP_JITTER_STEP_MS", "50"))  # per-pod dial stagger (pod index * this); replaces the old flat STARTSLEEP
+  # Per-pod startup jitter (pod index * this ms) to spread bootstrap dials and avoid
+  # simultaneous-dial collisions. Mainly for Shadow, which starts all hosts at the same
+  # simulated instant; real deployments get this spread naturally. Node availability
+  # before connect is handled by the readiness probe + publish_not_ready_addresses
+  # (10ksim#315), so no flat sync delay is needed here.
+  startupJitterStepMs* = parseInt(getEnv("STARTUP_JITTER_STEP_MS", "50"))
   metricsIntervalS* = parseInt(getEnv("METRICS_INTERVAL_S", "300"))  #storeMetrics scrape interval (s); short for shadow
 
 

--- a/nim-test-node/regression/env.nim
+++ b/nim-test-node/regression/env.nim
@@ -12,7 +12,7 @@ let
   prometheusPort* = Port(8008)
   myPort* = Port(5000)
   chunks* = parseInt(getEnv("FRAGMENTS", "1"))                  #No. of fragments for each message
-  start_sleep* = parseInt(getEnv("STARTSLEEP", "180"))          # Give time to deploy all nodes before starting connections
+  startupJitterStepMs* = parseInt(getEnv("STARTUP_JITTER_STEP_MS", "50"))  # per-pod dial stagger (pod index * this); replaces the old flat STARTSLEEP
   metricsIntervalS* = parseInt(getEnv("METRICS_INTERVAL_S", "300"))  #storeMetrics scrape interval (s); short for shadow
 
 
@@ -32,7 +32,7 @@ proc getPeerDetails*(): Result[(int, string, string, string, NodeType), string] 
   if muxer.toLowerAscii() notin ["quic", "yamux", "mplex"]:
     return err("Unknown muxer type : " & muxer)
 
-  info "Host info ", hostname = hostname, peer = myId, muxer = muxer, inShadow = inShadow, address = address, start_sleep = start_sleep, role = nodeRole
+  info "Host info ", hostname = hostname, peer = myId, muxer = muxer, inShadow = inShadow, address = address, jitterStepMs = startupJitterStepMs, role = nodeRole
 
   return ok((myId, muxer, filePath, address, nodeRole))
 

--- a/nim-test-node/regression/main.nim
+++ b/nim-test-node/regression/main.nim
@@ -218,9 +218,10 @@ proc main {.async.} =
     await sleepAsync(2.days)
     return
 
-  # Normal node: dial the bootstrap (after a delay so the network is up), seed its
-  # peers into the routing table, and do one bootstrap round to populate it.
-  await sleepAsync(start_sleep.seconds)
+  # Normal node: stagger the bootstrap dial by pod index (a small per-pod delay) so
+  # 1000 nodes don't stampede the bootstrap at once, then seed its peers into the
+  # routing table and do one bootstrap round to populate it.
+  await sleepAsync((myId * startupJitterStepMs).milliseconds)
   let service = getEnv("SERVICE", "bootstrap")
   let bootstraps = (await connectToBootstrap(switch, muxer, service)).valueOr:
     error "Failed to connect to bootstrap", service = service, error = error


### PR DESCRIPTION
Replace the flat `STARTSLEEP` (180s) wait before a normal node dials the bootstrap with a small per-pod delay (`pod index * STARTUP_JITTER_STEP_MS`, default 50ms), so nodes spread their dials instead of all waiting three minutes and then stampeding the bootstrap at once.

The flat delay it replaces served two purposes:

- Avoid stampeding the bootstrap: now the per-pod jitter (which also breaks up the simultaneous dials that collapse quic under Shadow).
- Guard against static-mode connection hoarding: in static discovery the first-deployed nodes fill their connection slots among themselves, leaving latecomers unable to find non-full peers. This node runs kad-dht discovery, where peers are found dynamically so that doesn't arise; and even in static it stays fine at 1000 nodes, since each node dials only a sparse CONNECTTO set (~10 inbound on average, well under the connection cap).

Node availability before connecting is handled by the readiness probe + `publish_not_ready_addresses` (10ksim#315), so the flat sync wait isn't needed.