### PR TITLE
Shadow quic: floor lsquic engine tick re-arms

### DIFF
--- a/nim-test-node/regression/Dockerfile_amd64_shadow
+++ b/nim-test-node/regression/Dockerfile_amd64_shadow
@@ -34,9 +34,8 @@ COPY . .
 RUN nimble refresh
 RUN nimble install -dy --verbose
 
-# Floor lsquic's engine tick re-arms, switched at runtime by LSQUIC_TICK_FLOOR_US
-# (unset/0 = stock). Shadow livelocks on lsquic's diff=0 "tick now" re-arm.
-# Patch the package cache: `nimble c` re-resolves and reinstalls over pkgs2.
+# Floor lsquic's engine tick re-arms so Shadow can advance simulated time.
+# Gated by LSQUIC_TICK_FLOOR_US (unset/0 = stock). See README.md.
 COPY lsquic-tick-floor.patch /tmp/lsquic-tick-floor.patch
 RUN set -eu; \
     patched=0; \

--- a/nim-test-node/regression/Dockerfile_amd64_shadow
+++ b/nim-test-node/regression/Dockerfile_amd64_shadow
@@ -34,13 +34,31 @@ COPY . .
 RUN nimble refresh
 RUN nimble install -dy --verbose
 
+# Floor lsquic's engine tick re-arms, switched at runtime by LSQUIC_TICK_FLOOR_US
+# (unset/0 = stock). Shadow livelocks on lsquic's diff=0 "tick now" re-arm.
+# Patch the package cache: `nimble c` re-resolves and reinstalls over pkgs2.
+COPY lsquic-tick-floor.patch /tmp/lsquic-tick-floor.patch
+RUN set -eu; \
+    patched=0; \
+    for d in /root/.nimble/pkgcache/*lsquic*/ /root/.nimble/pkgs2/lsquic-*/; do \
+      [ -f "${d}lsquic/context/context.nim" ] || continue; \
+      if grep -q tickFloorUs "${d}lsquic/context/context.nim"; then echo "already patched $d"; continue; fi; \
+      ( cd "$d" && git apply -p1 /tmp/lsquic-tick-floor.patch ); \
+      echo "patched $d"; patched=$((patched+1)); \
+    done; \
+    [ "$patched" -gt 0 ] || { echo "no lsquic package found to patch"; exit 1; }
+
 # Dynamic link: no `-static`, no `-mmusl`, no `-static-libgcc/-libstdc++`.
 RUN nimble c \
     --os:linux --cpu:amd64 \
     -d:chronicles_colors=None --threads:on --mm:refc \
     -d:metrics -d:libp2p_network_protocols_metrics -d:release \
     main \
-    && chmod +x /node/main
+    && chmod +x /node/main \
+    && (grep -l tickFloorUs /root/.nimble/pkgs2/lsquic-*/lsquic/context/context.nim \
+        || echo "patch WIPED by nimble re-resolve") \
+    && grep -qa LSQUIC_TICK_FLOOR_US /node/main \
+    && echo "TICK-FLOOR VERIFIED IN BINARY"
 
 # Tiny final stage: the binary + its runtime deps. The image's role is to hand
 # off /node/main to an init container, not to run anything itself. We still

--- a/nim-test-node/regression/README.md
+++ b/nim-test-node/regression/README.md
@@ -1,0 +1,26 @@
+# Regression test node
+
+Node for nim-libp2p regression campaigns. `Dockerfile_amd64` builds the static
+cluster binary; `Dockerfile_amd64_shadow` builds the dynamic one for Shadow
+(its syscall interposer only hooks dynamically linked ELFs).
+
+## The lsquic tick-floor patch (Shadow + quic only)
+
+`lsquic-tick-floor.patch`, applied by `Dockerfile_amd64_shadow`, is the reason
+quic runs under Shadow at all. lsquic re-arms its engine tick with a zero delay;
+in a discrete-event simulator that self-rescheduling timer never lets simulated
+time advance, so the run livelocks at one instant. mplex and yamux are fine.
+
+The patch floors the re-arm interval, gated by `LSQUIC_TICK_FLOOR_US` (unset/0 =
+stock, so the image is safe on the cluster too; campaigns use `10000`, 10 ms).
+`es_clock_granularity` is a real lsquic setting, but the essential change floors
+nim-lsquic's own chronos re-arm, which has no upstream knob; the durable fix is
+exposing both upstream in nim-lsquic.
+
+## Maintaining the patch
+
+It targets lsquic 0.5.4's layout, pinned in `test_node.nimble`. `nimble c`
+re-resolves deps before compiling, so the Dockerfile patches the package cache
+(`~/.nimble/pkgcache`, what nimble copies from) rather than the installed copy.
+The build asserts it patched something and greps the binary for
+`LSQUIC_TICK_FLOOR_US`, so a stock build or a stale pin fails loudly.

--- a/nim-test-node/regression/lsquic-tick-floor.patch
+++ b/nim-test-node/regression/lsquic-tick-floor.patch
@@ -1,0 +1,81 @@
+diff -ruN orig/lsquic/context/client.nim patched/lsquic/context/client.nim
+--- orig/lsquic/context/client.nim	2026-07-10 11:58:45
++++ patched/lsquic/context/client.nim	2026-07-10 12:00:04
+@@ -141,6 +141,8 @@
+   ctx.settings.es_max_sfcw = 2 * 1024 * 1024
+   ctx.settings.es_init_max_stream_data_bidi_local = ctx.settings.es_sfcw
+   ctx.settings.es_init_max_stream_data_bidi_remote = ctx.settings.es_sfcw
++  if tickFloorUs > 0:
++    ctx.settings.es_clock_granularity = tickFloorUs.cuint
+ 
+   ctx.stream_if = struct_lsquic_stream_if(
+     on_new_conn: onNewConn,
+diff -ruN orig/lsquic/context/context.nim patched/lsquic/context/context.nim
+--- orig/lsquic/context/context.nim	2026-07-10 11:58:45
++++ patched/lsquic/context/context.nim	2026-07-10 12:00:04
+@@ -1,7 +1,7 @@
+ # SPDX-License-Identifier: Apache-2.0 OR MIT
+ # Copyright (c) Status Research & Development GmbH 
+ 
+-import std/[deques, hashes, sets, strutils]
++import std/[deques, hashes, sets, strutils, os]
+ import boringssl
+ import chronos
+ import chronos/osdefs
+@@ -12,6 +12,18 @@
+ let SSL_CTX_ID = SSL_CTX_get_ex_new_index(0, nil, nil, nil, nil) # Yes, this is global
+ doAssert SSL_CTX_ID >= 0, "could not generate global ssl_ctx id"
+ 
++# Optional floor (microseconds) on engine tick re-arm intervals, read from
++# LSQUIC_TICK_FLOOR_US. Coarsens the wake-up cadence for discrete-event
++# simulators (e.g. Shadow), where the default 1ms/sub-ms per-engine ticks
++# explode the event volume. 0 (default) keeps stock behavior.
++let tickFloorUs* = block:
++  var v = 0
++  try:
++    v = parseInt(getEnv("LSQUIC_TICK_FLOOR_US", "0"))
++  except ValueError:
++    discard
++  max(v, 0)
++
+ type
+   CidKey* = object
+     len*: uint8
+@@ -112,7 +124,10 @@
+ 
+   if ctx.processing:
+     if not ctx.tickTimeout.isNil:
+-      ctx.tickTimeout.set(Moment.now())
++      if tickFloorUs > 0:
++        ctx.tickTimeout.set(tickFloorUs.microseconds)
++      else:
++        ctx.tickTimeout.set(Moment.now())
+     return
+ 
+   ctx.processing = true
+@@ -128,9 +143,10 @@
+   if lsquic_engine_earliest_adv_tick(ctx.engine, addr diff) == 0:
+     return
+ 
+-  let delta =
+-    if diff < 0: LSQUIC_DF_CLOCK_GRANULARITY.microseconds else: diff.microseconds
+-  ctx.tickTimeout.set(delta)
++  var deltaUs = if diff < 0: LSQUIC_DF_CLOCK_GRANULARITY.int else: diff.int
++  if deltaUs < tickFloorUs:
++    deltaUs = tickFloorUs
++  ctx.tickTimeout.set(deltaUs.microseconds)
+ 
+ proc stop*(ctx: QuicContext) {.raises: [].} =
+   ## Quiesce the context before closing the UDP transport so late datagrams and
+diff -ruN orig/lsquic/context/server.nim patched/lsquic/context/server.nim
+--- orig/lsquic/context/server.nim	2026-07-10 11:58:45
++++ patched/lsquic/context/server.nim	2026-07-10 12:00:04
+@@ -75,6 +75,8 @@
+   ctx.settings.es_max_sfcw = 1 * 1024 * 1024
+   ctx.settings.es_init_max_stream_data_bidi_local = ctx.settings.es_sfcw
+   ctx.settings.es_init_max_stream_data_bidi_remote = ctx.settings.es_sfcw
++  if tickFloorUs > 0:
++    ctx.settings.es_clock_granularity = tickFloorUs.cuint
+ 
+   ctx.stream_if = struct_lsquic_stream_if(
+     on_new_conn: onNewConn,

--- a/nim-test-node/regression/test_node.nimble
+++ b/nim-test-node/regression/test_node.nimble
@@ -11,4 +11,6 @@ skipDirs      = @[]
 
 requires "nim >= 2.2.0",
           "nimcrypto 0.6.4",
-          "https://github.com/vacp2p/nim-libp2p#26e181e4dd65188051ab4783bcc538ed9579644f" # 2.0.0
+          "https://github.com/vacp2p/nim-libp2p#26e181e4dd65188051ab4783bcc538ed9579644f", # 2.0.0
+          # The shadow image's tick-floor patch targets lsquic 0.5.4's layout.
+          "lsquic >= 0.5.4 & < 0.5.5"


### PR DESCRIPTION
Makes quic runnable under Shadow. Without the floor, lsquic's zero-delay tick re-arm livelocks the simulator at a single simulated instant.