### PR TITLE
Await the metrics server start instead of waitFor

### DIFF
--- a/nim-test-node/regression/env.nim
+++ b/nim-test-node/regression/env.nim
@@ -47,7 +47,9 @@ proc getPeerDetails*(): Result[(int, string, string, string, NodeType), string] 
 #Prometheus metrics
 proc startMetricsServer*(
     serverIp: IpAddress, serverPort: Port
-): Result[MetricsHttpServerRef, string] =
+): Future[Result[MetricsHttpServerRef, string]] {.async.} =
+  ## Awaits the server start rather than `waitFor`-ing it: the only caller is async, and
+  ## running the event loop from inside it re-enters the loop.
   info "Starting metrics HTTP server", serverIp = $serverIp, serverPort = $serverPort
 
   let metricsServerRes = MetricsHttpServerRef.new($serverIp, serverPort)
@@ -56,7 +58,9 @@ proc startMetricsServer*(
 
   let server = metricsServerRes.value
   try:
-    waitFor server.start()
+    await server.start()
+  except CancelledError as exc:
+    raise exc
   except CatchableError:
     return err("metrics HTTP server start failed: " & getCurrentExceptionMsg())
 

--- a/nim-test-node/regression/env.nim
+++ b/nim-test-node/regression/env.nim
@@ -48,8 +48,7 @@ proc getPeerDetails*(): Result[(int, string, string, string, NodeType), string] 
 proc startMetricsServer*(
     serverIp: IpAddress, serverPort: Port
 ): Future[Result[MetricsHttpServerRef, string]] {.async.} =
-  ## Awaits the server start rather than `waitFor`-ing it: the only caller is async, and
-  ## running the event loop from inside it re-enters the loop.
+  ## Awaited, not `waitFor`-ed: the only caller is async.
   info "Starting metrics HTTP server", serverIp = $serverIp, serverPort = $serverPort
 
   let metricsServerRes = MetricsHttpServerRef.new($serverIp, serverPort)

--- a/nim-test-node/regression/main.nim
+++ b/nim-test-node/regression/main.nim
@@ -211,7 +211,7 @@ proc main {.async.} =
   discard gossipSub.startHttpServer(myId)
 
   info "Starting metrics server"
-  let metricsServer = startMetricsServer(parseIpAddress("0.0.0.0"), prometheusPort)
+  let metricsServer = await startMetricsServer(parseIpAddress("0.0.0.0"), prometheusPort)
   if metricsServer.isErr:
     error "Failed to initialize metrics server", err = metricsServer.error
   elif inShadow:


### PR DESCRIPTION
waitFor runs the event loop from inside `{.async.} main`; chronos 4.4.0 rejects it as an illegal NestedPoll effect, so the node does not build against current chronos.